### PR TITLE
Fix pattern matching mistake in file_open

### DIFF
--- a/src/mist_ffi.erl
+++ b/src/mist_ffi.erl
@@ -34,8 +34,8 @@ string_to_int(String, Base) ->
 
 file_open(Path) ->
   case file:open(Path, [raw]) of
-    {ok, fd} ->
-      {ok, fd};
+    {ok, Fd} ->
+      {ok, Fd};
     {error, enoent} ->
       {error, no_entry};
     {error, eacces} ->


### PR DESCRIPTION
It would appear the `mist_ffi.file_open` would always return an `unknown_file_error` since it tries to match the success case on `{ok, fd}` rather than `{ok, Fd}`. With this fix, things seem to work smoothly.