### PR TITLE
Include protocol

### DIFF
--- a/src/mist.gleam
+++ b/src/mist.gleam
@@ -301,7 +301,7 @@ pub fn new(handler: fn(Request(in)) -> Response(out)) -> Builder(in, out) {
     port: 4000,
     handler: handler,
     after_start: fn(port) {
-      let message = "Listening on localhost:" <> int.to_string(port)
+      let message = "Listening on http://localhost:" <> int.to_string(port)
       io.println(message)
     },
   )


### PR DESCRIPTION
Hello!

In vscode I wanted to be able to click on the URL to visit the site, but I was unable without the protocol.

This could be incorrect if the programmer starts the server on HTTP. Perhaps this function could also take the scheme as a parameter?