### PR TITLE
fix an issue where websocket crashes on internal control closeframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove WebSocket builder in favor of plain function
 - Adds `on_init` and `on_close` to WebSocket upgrade function
+- Fix an issue where websocket crashes on internal control close frame
 
 ## v0.13.2
 

--- a/src/mist/internal/websocket.gleam
+++ b/src/mist/internal/websocket.gleam
@@ -230,11 +230,10 @@ pub fn initialize_connection(
     loop: fn(msg, state) {
       case msg {
         Valid(Internal(Control(CloseFrame(..)) as frame)) -> {
-          let assert Ok(_) =
-            connection.transport.send(
-              connection.socket,
-              frame_to_bit_builder(frame),
-            )
+          connection.transport.send(
+            connection.socket,
+            frame_to_bit_builder(frame),
+          )
           on_close()
           actor.Stop(process.Normal)
         }


### PR DESCRIPTION
Potentially fixes an issue where websocket crashes on internal control closeframe.

The assertion being made in `src/mist/internal/websocket.gleam:232` crashes a webserver using mist websockets when the call returns an error.

This fix appears to conform to the patterns in other case clauses, where there is no assertion made to the result from `connection.transport.send`. Given a better understanding of the purpose of this function however, there may be a better way to approach this.

Closes #24