### PR TITLE
fix example in readme for recent gleam

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ in the examples below).
 ```gleam
 import gleam/bytes_builder
 import gleam/erlang/process
-import gleam/http/request.{Request}
-import gleam/http/response.{Response}
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
 import gleam/io
 import gleam/iterator
 import gleam/option.{None, Some}
 import gleam/otp/actor
 import gleam/result
 import gleam/string
-import mist.{Connection, ResponseData}
+import mist.{type Connection, type ResponseData}
 
 pub fn main() {
   // These values are for the Websocket process initialized below


### PR DESCRIPTION
following Gleam 0.33 in December the only way to import a type should be with type keyword, with recent gleam the example in readme does not compile and throws error:
```
The module `mist` does not have a `Connection` value.
```
- new synax introduced in Gleam 0.32: https://gleam.run/news/v0.32-polishing-syntax-for-stability/
- removal of old syntax confirmed here: https://gleam.run/news/v0.33-exhaustive-gleam/