### PR TITLE
Fix deprecation warnings for gleam stdlib

### DIFF
--- a/examples/complete/src/complete.gleam
+++ b/examples/complete/src/complete.gleam
@@ -1,4 +1,4 @@
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/dict.{type Dict}
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process
@@ -39,7 +39,7 @@ pub fn main() {
 
   let not_found =
     response.new(404)
-    |> response.set_body(mist.Bytes(bytes_builder.new()))
+    |> response.set_body(mist.Bytes(bytes_tree.new()))
 
   let assert Ok(_) =
     fn(req: Request(Connection)) -> Response(ResponseData) {
@@ -52,7 +52,7 @@ pub fn main() {
           response.new(200)
           |> response.prepend_header("my-value", "abc")
           |> response.prepend_header("my-value", "123")
-          |> response.set_body(mist.Bytes(bytes_builder.from_string(index)))
+          |> response.set_body(mist.Bytes(bytes_tree.from_string(index)))
         ["ws"] ->
           mist.websocket(
             request: req,
@@ -107,12 +107,12 @@ fn echo_body(request: Request(Connection)) -> Response(ResponseData) {
   mist.read_body(request, 1024 * 1024 * 10)
   |> result.map(fn(req) {
     response.new(200)
-    |> response.set_body(mist.Bytes(bytes_builder.from_bit_array(req.body)))
+    |> response.set_body(mist.Bytes(bytes_tree.from_bit_array(req.body)))
     |> response.set_header("content-type", content_type)
   })
   |> result.lazy_unwrap(fn() {
     response.new(400)
-    |> response.set_body(mist.Bytes(bytes_builder.new()))
+    |> response.set_body(mist.Bytes(bytes_tree.new()))
   })
 }
 
@@ -124,7 +124,7 @@ fn serve_chunk(_request: Request(Connection)) -> Response(ResponseData) {
       process.sleep(2000)
       data
     })
-    |> iterator.map(bytes_builder.from_string)
+    |> iterator.map(bytes_tree.from_string)
 
   response.new(200)
   |> response.set_body(mist.Chunked(iter))
@@ -147,14 +147,14 @@ fn serve_file(
   })
   |> result.lazy_unwrap(fn() {
     response.new(404)
-    |> response.set_body(mist.Bytes(bytes_builder.new()))
+    |> response.set_body(mist.Bytes(bytes_tree.new()))
   })
 }
 
 fn handle_form(req: Request(Connection)) -> Response(ResponseData) {
   let _req = mist.read_body(req, 1024 * 1024 * 30)
   response.new(200)
-  |> response.set_body(mist.Bytes(bytes_builder.new()))
+  |> response.set_body(mist.Bytes(bytes_tree.new()))
 }
 
 fn guess_content_type(_path: String) -> String {

--- a/examples/eventz/src/eventz.gleam
+++ b/examples/eventz/src/eventz.gleam
@@ -1,4 +1,4 @@
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/function
 import gleam/http/request
@@ -6,7 +6,7 @@ import gleam/http/response
 import gleam/int
 import gleam/otp/actor
 import gleam/string
-import gleam/string_builder
+import gleam/string_tree
 import logging
 import mist
 import repeatedly
@@ -52,7 +52,7 @@ pub fn main() {
 
   let index_resp =
     response.new(200)
-    |> response.set_body(mist.Bytes(bytes_builder.from_string(index_html)))
+    |> response.set_body(mist.Bytes(bytes_tree.from_string(index_html)))
 
   let assert Ok(_) =
     fn(req) {
@@ -79,7 +79,7 @@ pub fn main() {
               case message {
                 Time(value) -> {
                   let event =
-                    mist.event(string_builder.from_string(int.to_string(value)))
+                    mist.event(string_tree.from_string(int.to_string(value)))
                   case mist.send_event(conn, event) {
                     Ok(_) -> {
                       logging.log(

--- a/gleam.toml
+++ b/gleam.toml
@@ -20,6 +20,7 @@ gramps = "~> 2.0"
 hpack_erl = "~> 0.3"
 logging = "~> 1.0"
 glisten = ">= 6.0.0 and < 7.0.0"
+gleam_yielder = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,7 +9,8 @@ packages = [
   { name = "gleam_hackney", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "066B1A55D37DBD61CC72A1C4EDE43C6015B1797FAF3818C16FE476534C7B6505" },
   { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "gleam_stdlib", version = "0.44.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "A6E55E309A6778206AAD4038D9C49E15DF71027A1DB13C6ADA06BFDB6CF1260E" },
+  { name = "gleam_yielder", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "44C8DE196A10634667F5F7B93128A997B35DFD37E26F775D749BC6A239B499A8" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glisten", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "912132751031473CB38F454120124FFC96AF6B0EA33D92C9C90DB16327A2A972" },
   { name = "gramps", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "3CCAA6E081225180D95C79679D383BBF51C8D1FDC1B84DA1DA444F628C373793" },
@@ -33,6 +34,7 @@ gleam_hackney = { version = "~> 1.2" }
 gleam_http = { version = "~> 3.5" }
 gleam_otp = { version = "~> 0.9" }
 gleam_stdlib = { version = "~> 0.35 or ~> 1.0" }
+gleam_yielder = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
 glisten = { version = ">= 6.0.0 and < 7.0.0" }
 gramps = { version = "~> 2.0" }

--- a/src/mist.gleam
+++ b/src/mist.gleam
@@ -1,5 +1,6 @@
+import gleam/yielder.{type Yielder}
 import gleam/bit_array
-import gleam/bytes_builder.{type BytesBuilder}
+import gleam/bytes_tree.{type BytesTree}
 import gleam/erlang.{rescue}
 import gleam/erlang/process.{type ProcessDown, type Selector, type Subject}
 import gleam/function
@@ -8,14 +9,13 @@ import gleam/http/request.{type Request}
 import gleam/http/response.{type Response}
 import gleam/int
 import gleam/io
-import gleam/iterator.{type Iterator}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/otp/supervisor
 import gleam/result
 import gleam/string
-import gleam/string_builder.{type StringBuilder}
+import gleam/string_tree.{type StringTree}
 import glisten
 import glisten/transport
 import gramps/websocket.{BinaryFrame, Data, TextFrame} as gramps_websocket
@@ -96,8 +96,8 @@ pub fn get_client_info(conn: Connection) -> Result(ConnectionInfo, Nil) {
 /// Erlang's `sendfile` to more efficiently return a file to the client.
 pub type ResponseData {
   Websocket(Selector(ProcessDown))
-  Bytes(BytesBuilder)
-  Chunked(Iterator(BytesBuilder))
+  Bytes(BytesTree)
+  Chunked(Yielder(BytesTree))
   /// See `mist.send_file` to use this response type.
   File(descriptor: file.FileDescriptor, offset: Int, length: Int)
   ServerSentEvents(Selector(ProcessDown))
@@ -666,7 +666,7 @@ pub fn websocket(
   })
   |> result.lazy_unwrap(fn() {
     response.new(400)
-    |> response.set_body(Bytes(bytes_builder.new()))
+    |> response.set_body(Bytes(bytes_tree.new()))
   })
 }
 
@@ -732,11 +732,11 @@ pub opaque type SSEConnection {
 // default to `message`.  If an `id` is provided, it will be included in the
 // event received by the client.
 pub opaque type SSEEvent {
-  SSEEvent(id: Option(String), event: Option(String), data: StringBuilder)
+  SSEEvent(id: Option(String), event: Option(String), data: StringTree)
 }
 
 // Builder for generating the base event
-pub fn event(data: StringBuilder) -> SSEEvent {
+pub fn event(data: StringTree) -> SSEEvent {
   SSEEvent(id: None, event: None, data: data)
 }
 
@@ -776,14 +776,14 @@ pub fn server_sent_events(
     req.body.socket,
     encoder.response_builder(200, with_default_headers.headers, "1.1"),
   )
-  |> result.nil_error
+  |> result.replace_error(Nil)
   |> result.then(fn(_nil) {
     actor.start_spec(
       actor.Spec(init: init, init_timeout: 1000, loop: fn(state, message) {
         loop(state, SSEConnection(req.body), message)
       }),
     )
-    |> result.nil_error
+    |> result.replace_error(Nil)
   })
   |> result.map(fn(subj) {
     let sse_process = process.subject_owner(subj)
@@ -796,7 +796,7 @@ pub fn server_sent_events(
   })
   |> result.lazy_unwrap(fn() {
     response.new(400)
-    |> response.set_body(Bytes(bytes_builder.new()))
+    |> response.set_body(Bytes(bytes_tree.new()))
   })
 }
 
@@ -816,18 +816,18 @@ pub fn send_event(conn: SSEConnection, event: SSEEvent) -> Result(Nil, Nil) {
     |> option.unwrap("")
   let data =
     event.data
-    |> string_builder.split("\n")
-    |> list.map(fn(row) { string_builder.prepend(row, "data: ") })
-    |> string_builder.join("\n")
+    |> string_tree.split("\n")
+    |> list.map(fn(row) { string_tree.prepend(row, "data: ") })
+    |> string_tree.join("\n")
 
   let message =
     data
-    |> string_builder.prepend(event_name)
-    |> string_builder.prepend(id)
-    |> string_builder.append("\n\n")
-    |> bytes_builder.from_string_builder
+    |> string_tree.prepend(event_name)
+    |> string_tree.prepend(id)
+    |> string_tree.append("\n\n")
+    |> bytes_tree.from_string_tree
 
   transport.send(conn.transport, conn.socket, message)
   |> result.replace(Nil)
-  |> result.nil_error
+  |> result.replace_error(Nil)
 }

--- a/src/mist/internal/encoder.gleam
+++ b/src/mist/internal/encoder.gleam
@@ -1,37 +1,34 @@
-import gleam/bytes_builder.{type BytesBuilder}
+import gleam/bytes_tree.{type BytesTree}
 import gleam/http.{type Header}
 import gleam/http/response.{type Response}
 import gleam/int
 import gleam/list
 
 /// Turns an HTTP response into a TCP message
-pub fn to_bytes_builder(
-  resp: Response(BytesBuilder),
-  version: String,
-) -> BytesBuilder {
+pub fn to_bytes_tree(resp: Response(BytesTree), version: String) -> BytesTree {
   resp.status
   |> response_builder(resp.headers, version)
-  |> bytes_builder.append_builder(resp.body)
+  |> bytes_tree.append_tree(resp.body)
 }
 
 pub fn response_builder(
   status: Int,
   headers: List(Header),
   version: String,
-) -> BytesBuilder {
+) -> BytesTree {
   let status_string =
     status
     |> int.to_string
-    |> bytes_builder.from_string
-    |> bytes_builder.append(<<" ":utf8>>)
-    |> bytes_builder.append(status_to_bit_array(status))
+    |> bytes_tree.from_string
+    |> bytes_tree.append(<<" ":utf8>>)
+    |> bytes_tree.append(status_to_bit_array(status))
 
-  bytes_builder.new()
-  |> bytes_builder.append(<<"HTTP/":utf8, version:utf8, " ":utf8>>)
-  |> bytes_builder.append_builder(status_string)
-  |> bytes_builder.append(<<"\r\n":utf8>>)
-  |> bytes_builder.append_builder(encode_headers(headers))
-  |> bytes_builder.append(<<"\r\n":utf8>>)
+  bytes_tree.new()
+  |> bytes_tree.append(<<"HTTP/":utf8, version:utf8, " ":utf8>>)
+  |> bytes_tree.append_tree(status_string)
+  |> bytes_tree.append(<<"\r\n":utf8>>)
+  |> bytes_tree.append_tree(encode_headers(headers))
+  |> bytes_tree.append(<<"\r\n":utf8>>)
 }
 
 pub fn status_to_bit_array(status: Int) -> BitArray {
@@ -95,14 +92,14 @@ pub fn status_to_bit_array(status: Int) -> BitArray {
   }
 }
 
-pub fn encode_headers(headers: List(Header)) -> BytesBuilder {
-  list.fold(headers, bytes_builder.new(), fn(builder, tup) {
+pub fn encode_headers(headers: List(Header)) -> BytesTree {
+  list.fold(headers, bytes_tree.new(), fn(builder, tup) {
     let #(header, value) = tup
 
     builder
-    |> bytes_builder.append_string(header)
-    |> bytes_builder.append(<<": ":utf8>>)
-    |> bytes_builder.append_string(value)
-    |> bytes_builder.append(<<"\r\n":utf8>>)
+    |> bytes_tree.append_string(header)
+    |> bytes_tree.append(<<": ":utf8>>)
+    |> bytes_tree.append_string(value)
+    |> bytes_tree.append(<<"\r\n":utf8>>)
   })
 }

--- a/src/mist/internal/file.gleam
+++ b/src/mist/internal/file.gleam
@@ -1,4 +1,4 @@
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/result
 import glisten.{type Socket, type SocketReason}
 import glisten/transport.{type Transport, Ssl, Tcp}
@@ -48,7 +48,7 @@ pub fn sendfile(
       pread(file_descriptor, offset, bytes)
       |> result.map_error(FileErr)
       |> result.then(fn(bits) {
-        transport.send(transport, socket, bytes_builder.from_bit_array(bits))
+        transport.send(transport, socket, bytes_tree.from_bit_array(bits))
         |> result.map_error(SocketErr)
       })
     }

--- a/src/mist/internal/handler.gleam
+++ b/src/mist/internal/handler.gleam
@@ -60,7 +60,7 @@ pub fn with_func(handler: Handler) -> Loop(Message, State) {
           Bytes(bytes) -> {
             resp
             |> response.set_body(bytes)
-            |> http2.send_bytes_builder(conn, state.send_hpack_context, id)
+            |> http2.send_bytes_tree(conn, state.send_hpack_context, id)
           }
           File(..) ->
             Error(process.Abnormal("File sending unsupported over HTTP/2"))

--- a/src/mist/internal/telemetry.gleam
+++ b/src/mist/internal/telemetry.gleam
@@ -62,7 +62,7 @@ pub fn log(
 ) -> Nil {
   let duration_string =
     dict.get(measurements, atom.create_from_string("duration"))
-    |> result.then(fn(val) { result.nil_error(dynamic.int(val)) })
+    |> result.then(fn(val) { result.replace_error(dynamic.int(val), Nil) })
     |> result.map(convert_time_unit(_, Native, Microsecond))
     |> result.map(fn(time) { " duration: " <> int.to_string(time) <> "μs, " })
     |> result.unwrap("")

--- a/src/mist/internal/websocket.gleam
+++ b/src/mist/internal/websocket.gleam
@@ -301,10 +301,7 @@ fn apply_frames(
       transport.send(
         connection.transport,
         connection.socket,
-        websocket.frame_to_bytes_builder(
-          Control(PongFrame(length, payload)),
-          None,
-        ),
+        websocket.frame_to_bytes_builder(Control(PongFrame(length, payload)), None),
       )
       |> result.map(fn(_nil) {
         set_active(connection.transport, connection.socket)

--- a/test/http1_test.gleam
+++ b/test/http1_test.gleam
@@ -1,5 +1,5 @@
 import gleam/bit_array
-import gleam/bytes_builder.{type BytesBuilder}
+import gleam/bytes_tree.{type BytesTree}
 import gleam/http
 import gleam/http/request
 import gleam/http/response.{type Response, Response}
@@ -23,14 +23,14 @@ pub type Instantiator {
   Inparallel
 }
 
-fn get_default_response() -> Response(BytesBuilder) {
+fn get_default_response() -> Response(BytesTree) {
   response.new(200)
   |> response.prepend_header("user-agent", "hackney/1.20.1")
   |> response.prepend_header("host", "localhost:8888")
   |> response.prepend_header("content-type", "application/octet-stream")
   |> response.prepend_header("content-length", "13")
   |> response.prepend_header("connection", "keep-alive")
-  |> response.set_body(bytes_builder.from_bit_array(<<"hello, world!":utf8>>))
+  |> response.set_body(bytes_tree.from_bit_array(<<"hello, world!":utf8>>))
 }
 
 pub fn it_echoes_with_data_test() {
@@ -72,7 +72,7 @@ pub fn it_supports_large_header_fields_test() {
     |> response.prepend_header("content-type", "application/octet-stream")
     |> response.prepend_header("content-length", "0")
     |> response.prepend_header("host", "localhost:8888")
-    |> response.set_body(bytes_builder.from_bit_array(<<>>))
+    |> response.set_body(bytes_tree.from_bit_array(<<>>))
 
   let resp = scaffold.with_server(8888, scaffold.default_handler, big_request)
 
@@ -98,7 +98,7 @@ pub fn it_rejects_large_requests_test() {
 
   let expected =
     response.new(413)
-    |> response.set_body(bytes_builder.from_bit_array(<<>>))
+    |> response.set_body(bytes_tree.from_bit_array(<<>>))
     |> response.prepend_header("content-length", "0")
     |> response.prepend_header("connection", "close")
 
@@ -138,7 +138,7 @@ pub fn it_supports_chunked_encoding_test() {
     |> response.prepend_header("host", "localhost:8888")
     |> response.prepend_header("connection", "keep-alive")
     |> response.prepend_header("content-length", "10000")
-    |> response.set_body(bytes_builder.from_string(string.repeat("a", 10_000)))
+    |> response.set_body(bytes_tree.from_string(string.repeat("a", 10_000)))
 
   bitstring_response_should_equal(actual, expected)
 }
@@ -159,7 +159,7 @@ pub fn it_supports_query_parameters_test() {
     get_default_response()
     |> response.set_header("content-length", "61")
     |> response.set_body(
-      bytes_builder.from_bit_array(<<
+      bytes_tree.from_bit_array(<<
         "something=123&another=true&a-complicated-one=is%20the%20thing":utf8,
       >>),
     )
@@ -178,7 +178,7 @@ pub fn it_handles_query_parameters_with_question_mark_test() {
   let expected =
     get_default_response()
     |> response.set_header("content-length", "7")
-    |> response.set_body(bytes_builder.from_bit_array(<<"%3F=123":utf8>>))
+    |> response.set_body(bytes_tree.from_bit_array(<<"%3F=123":utf8>>))
 
   string_response_should_equal(resp, expected)
 }
@@ -194,7 +194,7 @@ pub fn it_doesnt_mangle_query_test() {
   let expected =
     get_default_response()
     |> response.set_header("content-length", "4")
-    |> response.set_body(bytes_builder.from_bit_array(<<"test":utf8>>))
+    |> response.set_body(bytes_tree.from_bit_array(<<"test":utf8>>))
 
   string_response_should_equal(resp, expected)
 }
@@ -210,7 +210,7 @@ pub fn it_supports_expect_continue_header_test() {
 
   let expected_body =
     string.repeat("a", 1000)
-    |> bytes_builder.from_string
+    |> bytes_tree.from_string
 
   let expected =
     response.new(200)


### PR DESCRIPTION
This PR updates the gleam stdlib version and fixes the deprecation warnings due to renaming and moving of various modules, types and functions. (e.g `bytes_builder` -> `bytes_tree`, `iterator` -> `yielder`)

Unfortunately, this is a breaking change. The `Yielder` type is used in the public interface (in the `Chunked` constructor of the `ResponseData` type). Unlike `BytesTree` and `StringTree`, which are simply aliases to their old, deprecated versions, `Yielder` is now a separate package and so a distinct type from `Iterator`.