### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dependencies as follows:
 ```sh
 $ gleam new <your_project>
 $ cd <your_project>
-$ gleam add mist gleam_erlang gleam_http gleam_otp
+$ gleam add mist gleam_erlang gleam_http gleam_otp gleam_yielder
 ```
 
 The main entrypoints for your application are `mist.start_http` and


### PR DESCRIPTION
Update examples to not use any deprecated functions for Gleam v1.6.3 and `gleam_stdlib` >= 0.34.0 and < 2.0.0