### PR TITLE
fix gleam_http version clash

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ application_start_module = "mist@internal@clock"
 
 [dependencies]
 gleam_erlang = "~> 0.24"
-gleam_http = ">= 3.5.0 and < 5.0.0"
+gleam_http = ">= 4.0.0 and < 5.0.0"
 gleam_otp = "~> 0.9"
 gleam_stdlib = ">= 0.44.0 and < 1.0.0"
 hpack_erl = "~> 0.3"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,18 +2,18 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
+  { name = "certifi", version = "2.14.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EA59D87EF89DA429B8E905264FDEC3419F84F2215BB3D81E07A18AAC919026C3" },
   { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
   { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_hackney", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "A0F182181D116BACD85D961A6E1AA35D25091195BE6F38468ECC28956E2C1835" },
-  { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
+  { name = "gleam_hackney", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "0449AADBEBF3E979509A4079EE34B92EEE4162C5A0DC94F3DA2787E4777F6B45" },
+  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
   { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
-  { name = "gleam_stdlib", version = "0.54.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "723BA61A2BAE8D67406E59DD88CEA1B3C3F266FC8D70F64BE9FEC81B4505B927" },
+  { name = "gleam_stdlib", version = "0.55.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "32D8F4AE03771516950047813A9E359249BD9FBA5C33463FDB7B953D6F8E896B" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
   { name = "glisten", version = "7.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "1A53CF9FB3231A93FF7F1BD519A43DC968C1722F126CDD278403A78725FC5189" },
-  { name = "gramps", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "630BDE35E465511945253A06EBCDE8D5E4B8B1988F4AC6B8FAC297DEF55B4CA2" },
-  { name = "hackney", version = "1.20.1", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "FE9094E5F1A2A2C0A7D10918FEE36BFEC0EC2A979994CFF8CFE8058CD9AF38E3" },
+  { name = "gramps", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "59194B3980110B403EE6B75330DB82CDE05FC8138491C2EAEACBC7AAEF30B2E8" },
+  { name = "hackney", version = "1.23.0", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "6CD1C04CD15C81E5A493F167B226A15F0938A84FC8F0736EBE4DDCAB65C0B44E" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
@@ -28,7 +28,7 @@ packages = [
 [requirements]
 gleam_erlang = { version = "~> 0.24" }
 gleam_hackney = { version = "~> 1.2" }
-gleam_http = { version = ">= 3.5.0 and < 5.0.0" }
+gleam_http = { version = ">= 4.0.0 and < 5.0.0" }
 gleam_otp = { version = "~> 0.9" }
 gleam_stdlib = { version = ">= 0.44.0 and < 1.0.0" }
 gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }

--- a/src/mist/internal/http2/stream.gleam
+++ b/src/mist/internal/http2/stream.gleam
@@ -1,4 +1,3 @@
-import gleam/dynamic
 import gleam/erlang
 import gleam/erlang/process.{type Selector, type Subject}
 import gleam/function
@@ -152,8 +151,7 @@ pub fn make_request(
     [] -> Ok(req)
     [#("method", method), ..rest] -> {
       method
-      |> dynamic.from
-      |> ghttp.method_from_dynamic
+      |> ghttp.parse_method
       |> result.replace_error(Nil)
       |> result.map(request.set_method(req, _))
       |> result.then(make_request(rest, _))

--- a/test/http1_test.gleam
+++ b/test/http1_test.gleam
@@ -25,7 +25,7 @@ pub type Instantiator {
 
 fn get_default_response() -> Response(BytesTree) {
   response.new(200)
-  |> response.prepend_header("user-agent", "hackney/1.20.1")
+  |> response.prepend_header("user-agent", "hackney/1.23.0")
   |> response.prepend_header("host", "localhost:8888")
   |> response.prepend_header("content-type", "application/octet-stream")
   |> response.prepend_header("content-length", "13")
@@ -134,7 +134,7 @@ pub fn it_supports_chunked_encoding_test() {
 
   let expected =
     response.new(200)
-    |> response.prepend_header("user-agent", "hackney/1.20.1")
+    |> response.prepend_header("user-agent", "hackney/1.23.0")
     |> response.prepend_header("host", "localhost:8888")
     |> response.prepend_header("connection", "keep-alive")
     |> response.prepend_header("content-length", "10000")
@@ -214,7 +214,7 @@ pub fn it_supports_expect_continue_header_test() {
 
   let expected =
     response.new(200)
-    |> response.prepend_header("user-agent", "hackney/1.20.1")
+    |> response.prepend_header("user-agent", "hackney/1.23.0")
     |> response.prepend_header("host", "localhost:8888")
     |> response.prepend_header("connection", "keep-alive")
     |> response.prepend_header("content-type", "application/octet-stream")


### PR DESCRIPTION
 #64 seems to have caused an issue where creating a new project with mist & gleam_http will cause a build error because `method_from_dynamic` no longer exists in gleam_http v4. I have updated so v4 is the min version, but we could also just revert #64 I believe. unsure on what we prefer here :) 