### PR TITLE
docs: update `README.md` to remove references to functions removed in v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ $ cd <your_project>
 $ gleam add mist logging gleam_erlang gleam_http gleam_otp gleam_yielder
 ```
 
-The main entrypoint for your application is `mist.start`.
-The argument to this function is generated from the
-opaque `Builder` type. It can be constructed with the `mist.new` function, and
-fed updated configuration options with the associated methods (demonstrated
-in the examples below).
+The main entrypoint for your application is `mist.start`. The argument to this
+function is generated from the opaque `Builder` type. It can be constructed with
+the `mist.new` function, and fed updated configuration options with the
+associated methods (demonstrated in the examples below).
 
 ```gleam
 import gleam/bytes_tree

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $ cd <your_project>
 $ gleam add mist logging gleam_erlang gleam_http gleam_otp gleam_yielder
 ```
 
-The main entrypoints for your application are `mist.start_http` and
-`mist.start_https`. The argument to these functions is generated from the
+The main entrypoint for your application is `mist.start`.
+The argument to this function is generated from the
 opaque `Builder` type. It can be constructed with the `mist.new` function, and
 fed updated configuration options with the associated methods (demonstrated
 in the examples below).


### PR DESCRIPTION
Please let me know if this is incorrect, but my understanding is that `start_http` and `start_https` were replaced with `start` in v5.