### PR TITLE
fix: rename get_client_info to get_connection_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pub fn main() {
     fn(req: Request(Connection)) -> Response(ResponseData) {
       logging.log(
         logging.Info,
-        "Got a request from: " <> string.inspect(mist.get_client_info(req.body)),
+        "Got a request from: " <> string.inspect(mist.get_connection_info(req.body)),
       )
       case request.path_segments(req) {
         [] ->

--- a/examples/complete/src/complete.gleam
+++ b/examples/complete/src/complete.gleam
@@ -33,7 +33,8 @@ pub fn main() {
     fn(req: Request(Connection)) -> Response(ResponseData) {
       logging.log(
         logging.Info,
-        "Got a request from: " <> string.inspect(mist.get_client_info(req.body)),
+        "Got a request from: "
+          <> string.inspect(mist.get_connection_info(req.body)),
       )
       case request.path_segments(req) {
         [] ->

--- a/src/mist.gleam
+++ b/src/mist.gleam
@@ -116,7 +116,7 @@ pub type ConnectionInfo {
 }
 
 /// Tries to get the IP address and port of a connected client.
-pub fn get_client_info(conn: Connection) -> Result(ConnectionInfo, Nil) {
+pub fn get_connection_info(conn: Connection) -> Result(ConnectionInfo, Nil) {
   transport.peername(conn.transport, conn.socket)
   |> result.map(fn(pair) {
     ConnectionInfo(


### PR DESCRIPTION
# Original Issue
https://github.com/rawhat/mist/issues/72

## Summary
1. Renamed `mist.get_client_info(Connection) -> ConnectionInfo`  to `mist.get_connection_info()`.

## Additional Notes
1. I noticed the same naming convention being used in glisten. Might open a PR there as well if it's a simple rename.