### PR TITLE
Remove deprecated `result.unwrap_both`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- Removed usage of deprecated `result.unwrap_both`
+
 # v5.0.3
 - Replace custom `rescue` with the `exception` package
 - Bump `gramps` version for better WebSocket compression support

--- a/src/mist/internal/http.gleam
+++ b/src/mist/internal/http.gleam
@@ -316,15 +316,16 @@ pub fn parse_request(
         host_header
         |> string.split_once(":")
         |> result.unwrap(#(host_header, ""))
-      let port =
-        int.parse(port)
-        |> result.map_error(fn(_err) {
+
+      let port = case int.parse(port) {
+        Ok(port) -> port
+        Error(_) ->
           case scheme {
             http.Https -> 443
             http.Http -> 80
           }
-        })
-        |> result.unwrap_both
+      }
+
       let req =
         request.Request(
           body: Connection(..conn, body: Initial(rest)),


### PR DESCRIPTION
This PR removes every usage of `result.unwrap_both` since it's deprecated